### PR TITLE
Adjust events card details to be more legible

### DIFF
--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -98,7 +98,7 @@ export default withStyles((theme) => ({
     margin: "8px 0",
   },
   location: {
-    marginTop: 6,
+    marginTop: "6px",
     fontSize: "16px",
     lineHeight: "1.375em",
   },
@@ -114,7 +114,7 @@ export default withStyles((theme) => ({
     fontWeight: "600",
     padding: "12px 16px",
     borderRadius: "6px",
-    marginTop: 18,
-    maxWidth: 90,
+    marginTop: "18px",
+    maxWidth: "90px",
   },
 }))(EventCard);

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -28,15 +28,15 @@ const EventCard = ({ classes, className, event }) => {
         </div>
         <div className={classes.title}>{event.title}</div>
         <div className={classes.location}>{event.location}</div>
+        <a
+          href={event.registrationUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={classes.registerLink}
+        >
+          Register
+        </a>
       </div>
-      <a
-        href={event.registrationUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={classes.registerLink}
-      >
-        Register
-      </a>
     </div>
   );
 };
@@ -82,6 +82,8 @@ export default withStyles((theme) => ({
     borderBottomRightRadius: "4px",
   },
   details: {
+    display: "flex",
+    flexDirection: "column",
     borderLeft: "1px solid #cecece",
     padding: "8px 0 8px 16px",
     marginLeft: "16px",
@@ -96,7 +98,9 @@ export default withStyles((theme) => ({
     margin: "8px 0",
   },
   location: {
+    marginTop: 6,
     fontSize: "16px",
+    lineHeight: "1.375em",
   },
   registerLink: {
     display: "flex",
@@ -110,7 +114,7 @@ export default withStyles((theme) => ({
     fontWeight: "600",
     padding: "12px 16px",
     borderRadius: "6px",
-    alignSelf: "flex-end",
-    marginLeft: "4px",
+    marginTop: 18,
+    maxWidth: 90,
   },
 }))(EventCard);


### PR DESCRIPTION
Before:
<img width="417" alt="screen shot 2018-11-07 at 2 04 25 pm" src="https://user-images.githubusercontent.com/5051745/48160818-1cbe3780-e296-11e8-9404-9de211eb9264.png">

After:
<img width="418" alt="screen shot 2018-11-07 at 2 04 41 pm" src="https://user-images.githubusercontent.com/5051745/48160823-1fb92800-e296-11e8-8924-ed55200fbc4b.png">
