### PR TITLE
Remove gatsby-plugin-offline, add gatsby-plugin-remove-serviceworker

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -87,7 +87,7 @@ module.exports = {
         icon: `static${config.siteLogo}`,
       },
     },
-    "gatsby-plugin-offline",
+    "gatsby-plugin-remove-serviceworker",
     {
       resolve: "gatsby-plugin-feed",
       options: {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-plugin-nprogress": "^1.0.14",
     "gatsby-plugin-offline": "^1.0.18",
     "gatsby-plugin-react-helmet": "^2.0.11",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-sitemap": "^1.2.25",
     "gatsby-remark-images-contentful": "^1.0.2",
     "gatsby-remark-prismjs": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gatsby-plugin-manifest": "^1.0.27",
     "gatsby-plugin-netlify": "^1.0.21",
     "gatsby-plugin-nprogress": "^1.0.14",
-    "gatsby-plugin-offline": "^1.0.18",
     "gatsby-plugin-react-helmet": "^2.0.11",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-sitemap": "^1.2.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,6 +4808,11 @@ gatsby-plugin-react-helmet@^2.0.11:
   dependencies:
     babel-runtime "^6.26.0"
 
+gatsby-plugin-remove-serviceworker@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz#9fb433bc8bd766e14e1d3711c4ac6f051e1dff7c"
+  integrity sha1-n7QzvIvXZuFOHTcRxKxvBR4d/3w=
+
 gatsby-plugin-sharp@^1.6.48:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.48.tgz#9bb7515da9c7753b3065c51b2d35a0de5b9aa1f5"


### PR DESCRIPTION
Plan of attack:

- [x] Create this PR without the service-workers remove, test preview branch on netlify
- [x] Add the `gatsby-plugin-remove-serviceworker` to gatsby-config, remove the offline plugin
- [ ] Test the updated preview branch on netlify– it should now have the remove sw plugin
